### PR TITLE
docs: added CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# kytos-ng/core-reviewers team will be the default owners for everything in
+# the repo. Unless a later match takes precedence.
+* @kytos-ng/core-reviewers


### PR DESCRIPTION
Closes N/A

### Summary

Added CODEOWNERS file same as we have on other NApps repos

### Local Tests

N/A

### End-to-End Tests

N/A
